### PR TITLE
Prevent showing poi card if another screen was opened

### DIFF
--- a/LocationServices/LocationServices/Constants/StringConstants.swift
+++ b/LocationServices/LocationServices/Constants/StringConstants.swift
@@ -165,6 +165,10 @@ enum StringConstant {
         static let isTracking = "Tracking your device location"
     }
     
+    enum Errors {
+        static let requestCanceledCode = -999
+    }
+    
     static let units = "Units"
     static let dataProvider = "Data Provider"
     static let mapStyle = "Map style"

--- a/LocationServices/LocationServices/Networking/Services/LocationServiceable.swift
+++ b/LocationServices/LocationServices/Networking/Services/LocationServiceable.swift
@@ -7,11 +7,12 @@
 
 import Foundation
 import CoreLocation
+import AWSLocationXCF
 
 protocol LocationServiceable {
     func searchText(text: String, userLat: Double?, userLong: Double?, completion: @escaping (([SearchPresentation]) -> Void))
     func searchTextWithSuggestion(text: String, userLat: Double?, userLong: Double?, completion: @escaping (([SearchPresentation]) -> Void))
-    func searchWithPosition(text: [NSNumber], userLat: Double?, userLong: Double?, completion: @escaping ((Result<[SearchPresentation], Error>) -> Void))
+    func searchWithPosition(text: [NSNumber], userLat: Double?, userLong: Double?, completion: @escaping ((Result<[SearchPresentation], Error>) -> Void)) -> AWSLocationSearchPlaceIndexForPositionRequest
     func getPlace(with placeId: String, completion: @escaping(SearchPresentation?)->Void )
     
 }
@@ -43,8 +44,9 @@ struct LocationService: AWSLocationSearchService, LocationServiceable {
         }
     }
     
-    func searchWithPosition(text: [NSNumber], userLat: Double?, userLong: Double?, completion: @escaping ((Result<[SearchPresentation], Error>) -> Void)) {
-        searchWithPositionRequest(text: text) { response in
+    @discardableResult
+    func searchWithPosition(text: [NSNumber], userLat: Double?, userLong: Double?, completion: @escaping ((Result<[SearchPresentation], Error>) -> Void)) -> AWSLocationSearchPlaceIndexForPositionRequest {
+        return searchWithPositionRequest(text: text) { response in
             switch response {
             case .success(let resluts):
                 var userLocation: CLLocation? = nil

--- a/LocationServices/LocationServices/Scenes/Explore/Contracts/ExploreContracts.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Contracts/ExploreContracts.swift
@@ -20,6 +20,7 @@ protocol ExploreViewModelProtocol: AnyObject {
     func userLocationChanged(_ userLocation: CLLocationCoordinate2D)
     func loadPlace(for coordinates: CLLocationCoordinate2D, userLocation: CLLocationCoordinate2D?)
     func shouldShowWelcome() -> Bool
+    func cancelActiveRequests()
 }
 
 protocol ExploreViewModelOutputDelegate: AnyObject, AlertPresentable {
@@ -28,7 +29,7 @@ protocol ExploreViewModelOutputDelegate: AnyObject, AlertPresentable {
     
     func routeReCalculated(route: DirectionPresentation, departureLocation: CLLocationCoordinate2D, destinationLocation: CLLocationCoordinate2D, routeType: RouteTypes)
     func userReachedDestination(_ destination: MapModel)
-    func showAnnotation(model: SearchPresentation)
+    func showAnnotation(model: SearchPresentation, force: Bool)
 }
 
 protocol ExploreVCProtocol: AnyObject {

--- a/LocationServices/LocationServices/Scenes/Explore/Controller/ExploreVC.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Controller/ExploreVC.swift
@@ -58,6 +58,11 @@ final class ExploreVC: UIViewController, AlertPresentable {
         showWelcomeScreenIfNeeded()
     }
     
+    override func viewWillDisappear(_ animated: Bool) {
+        super.viewDidAppear(animated)
+        viewModel.cancelActiveRequests()
+    }
+    
     func setupHandlers() {
         exploreView.geofenceButtonAction = {
             self.delegate?.dismissSearchScene()
@@ -345,7 +350,8 @@ extension ExploreVC: CLLocationManagerDelegate {
         self.exploreView.show(selectedPlace: destination)
     }
     
-    func showAnnotation(model: SearchPresentation) {
+    func showAnnotation(model: SearchPresentation, force: Bool) {
+        guard force || (presentedViewController == nil && viewIfLoaded?.window != nil) else { return }
         showPoiCard(cardData: [MapModel(model: model)])
     }
 }

--- a/LocationServices/LocationServices/Services/LocationSearchService.swift
+++ b/LocationServices/LocationServices/Services/LocationSearchService.swift
@@ -15,7 +15,7 @@ enum LocationServiceConstant {
 protocol AWSLocationSearchService {
     func searchTextRequest(text: String, userLat: Double?, userLong: Double?, completion: @escaping([AWSLocationSearchForTextResult]?)->Void )
     func searchTextWithSuggesstionRequest(text: String, userLat: Double?, userLong: Double?, completion: @escaping([AWSLocationSearchForSuggestionsResult]?)->Void )
-    func searchWithPositionRequest(text: [NSNumber], completion: @escaping ((Result<[AWSLocationSearchForPositionResult], Error>) -> Void))
+    func searchWithPositionRequest(text: [NSNumber], completion: @escaping ((Result<[AWSLocationSearchForPositionResult], Error>) -> Void)) -> AWSLocationSearchPlaceIndexForPositionRequest
     func getPlaceRequest(with placeId: String, completion: @escaping(AWSLocationGetPlaceResponse?)->Void )
 }
 
@@ -95,7 +95,7 @@ extension AWSLocationSearchService {
         }
     }
     
-    func searchWithPositionRequest(text: [NSNumber], completion: @escaping ((Result<[AWSLocationSearchForPositionResult], Error>) -> Void)) {
+    func searchWithPositionRequest(text: [NSNumber], completion: @escaping ((Result<[AWSLocationSearchForPositionResult], Error>) -> Void)) -> AWSLocationSearchPlaceIndexForPositionRequest {
         let request = AWSLocationSearchPlaceIndexForPositionRequest()!
         request.language = Locale.currentLanguageIdentifier()
         request.position = text
@@ -114,6 +114,8 @@ extension AWSLocationSearchService {
             }
             return nil
         }
+        
+        return request
     }
 }
 


### PR DESCRIPTION
*Description of changes:*
Prevent showing poi card if another screen was opened.
For example: you tap on the map, annotation hasn't been shown still as we wait for fetch place info request to complete and user opens some other screen. The annotation in this case wouldn't be shown once we get place info

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
