### PR TITLE
Fixes/als 1294 dark logo

### DIFF
--- a/LocationServices/LocationServices.xcodeproj/project.pbxproj
+++ b/LocationServices/LocationServices.xcodeproj/project.pbxproj
@@ -367,6 +367,7 @@
 		F1E5F8FA29E98ABF00639EEC /* IntExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E5F8F929E98ABF00639EEC /* IntExtensionTests.swift */; };
 		F1E5F8FC29E98AFB00639EEC /* DoubleExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E5F8FB29E98AFB00639EEC /* DoubleExtensionTests.swift */; };
 		F1E5F8FE29E9916800639EEC /* MGLCoordinateBoundsExtensionTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1E5F8FD29E9916800639EEC /* MGLCoordinateBoundsExtensionTests.swift */; };
+		F1F0C5892A13C19E009C7151 /* GeneralHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F0C5882A13C19E009C7151 /* GeneralHelper.swift */; };
 		F1F8061829D571E9002BDF85 /* GeofenceUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F8061729D571E9002BDF85 /* GeofenceUITests.swift */; };
 		F1F8061A29D5EDCB002BDF85 /* TrackingUITests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F1F8061929D5EDCB002BDF85 /* TrackingUITests.swift */; };
 /* End PBXBuildFile section */
@@ -742,6 +743,7 @@
 		F1E5F8F929E98ABF00639EEC /* IntExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = IntExtensionTests.swift; sourceTree = "<group>"; };
 		F1E5F8FB29E98AFB00639EEC /* DoubleExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = DoubleExtensionTests.swift; sourceTree = "<group>"; };
 		F1E5F8FD29E9916800639EEC /* MGLCoordinateBoundsExtensionTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MGLCoordinateBoundsExtensionTests.swift; sourceTree = "<group>"; };
+		F1F0C5882A13C19E009C7151 /* GeneralHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeneralHelper.swift; sourceTree = "<group>"; };
 		F1F8061729D571E9002BDF85 /* GeofenceUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = GeofenceUITests.swift; sourceTree = "<group>"; };
 		F1F8061929D5EDCB002BDF85 /* TrackingUITests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TrackingUITests.swift; sourceTree = "<group>"; };
 		F1F8063229D7683E002BDF85 /* TrackingSimulateLocation.xctestplan */ = {isa = PBXFileReference; lastKnownFileType = text; path = TrackingSimulateLocation.xctestplan; sourceTree = "<group>"; };
@@ -1122,6 +1124,7 @@
 				8A50572229A0329B0047A203 /* AuthActionsHelper.swift */,
 				8A6C390529A25E480003666C /* Reachability.swift */,
 				8A3FD14B29A69CE000DFA6F6 /* PlaceholderAnimator.swift */,
+				F1F0C5882A13C19E009C7151 /* GeneralHelper.swift */,
 			);
 			path = Helpers;
 			sourceTree = "<group>";
@@ -3171,6 +3174,7 @@
 				ADC97395295F3F9C005AE918 /* MapNavigationView.swift in Sources */,
 				AD2AF0E1292EAC1C00149904 /* AboutViewModel.swift in Sources */,
 				ADC1249C2978A56E00B08C20 /* GeofenceDashboardContracts.swift in Sources */,
+				F1F0C5892A13C19E009C7151 /* GeneralHelper.swift in Sources */,
 				ADD5D7E2296F87FF0022480B /* AddGeofenceContracts.swift in Sources */,
 				AD2AF09F292EA91200149904 /* GeofenceCoordinator.swift in Sources */,
 				AD2AF064292E929C00149904 /* Coordinator.swift in Sources */,

--- a/LocationServices/LocationServices/Assets.xcassets/amazon_logo.imageset/Contents.json
+++ b/LocationServices/LocationServices/Assets.xcassets/amazon_logo.imageset/Contents.json
@@ -10,6 +10,7 @@
     "version" : 1
   },
   "properties" : {
-    "preserves-vector-representation" : true
+    "preserves-vector-representation" : true,
+    "template-rendering-intent" : "template"
   }
 }

--- a/LocationServices/LocationServices/Helpers/GeneralHelper.swift
+++ b/LocationServices/LocationServices/Helpers/GeneralHelper.swift
@@ -1,0 +1,31 @@
+//
+//  GeneralHelper.swift
+//  LocationServices
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Foundation
+import UIKit
+
+class GeneralHelper {
+    static func getAmazonMapLogo(mapImageType: MapStyleImages?) -> UIColor {
+        switch mapImageType {
+        case .darkGray,
+             .Imagery,
+             .hereImagery,
+             .hybrid:
+            return UIColor.white
+        case .light,
+             .street,
+             .navigation,
+             .explore,
+             .contrast,
+             .exploreTruck,
+             .lightGray:
+            return UIColor.black
+        default:
+            return UIColor.black
+        }
+    }
+}

--- a/LocationServices/LocationServices/Scenes/Explore/Views/ExploreView.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Views/ExploreView.swift
@@ -413,7 +413,7 @@ final class ExploreView: UIView, NavigationMapProtocol {
         
         // it is just to force to redraw the mapView
         mapView.zoomLevel = mapView.zoomLevel + 0.01
-        
+        amazonMapLogo.tintColor = GeneralHelper.getAmazonMapLogo(mapImageType: mapName?.imageType)
         mapView.showsUserLocation = true
         locateMeAction(force: true)
     }

--- a/LocationServices/LocationServices/Scenes/Geofence/Views/GeofenceView.swift
+++ b/LocationServices/LocationServices/Scenes/Geofence/Views/GeofenceView.swift
@@ -120,6 +120,8 @@ final class GeofenceMapView: UIView {
     func reloadMap() {
         mapView.setupMapView()
         deselectAnnotation()
+        let mapName = UserDefaultsHelper.getObject(value: MapStyleModel.self, key: .mapStyle)
+        amazonMapLogo.tintColor = GeneralHelper.getAmazonMapLogo(mapImageType: mapName?.imageType)
     }
     
     func deselectAnnotation() {

--- a/LocationServices/LocationServices/Scenes/Tracking/Views/TrackingViews.swift
+++ b/LocationServices/LocationServices/Scenes/Tracking/Views/TrackingViews.swift
@@ -111,6 +111,8 @@ final class TrackingMapView: UIView {
     
     func reloadMap() {
         mapView.setupMapView()
+        let mapName = UserDefaultsHelper.getObject(value: MapStyleModel.self, key: .mapStyle)
+        amazonMapLogo.tintColor = GeneralHelper.getAmazonMapLogo(mapImageType: mapName?.imageType)
     }
     
     func removeGeofencesFromMap() {


### PR DESCRIPTION
Dark logo for Amazon Location Service on the bottom left side of the map is great but it's hard to see when using dark mode on a map. We should switch to a lighter logo based on the color of the map selected.
