### PR TITLE
Fixed ALS-1560 directions button & Navigation duration overlap

### DIFF
--- a/LocationServices/LocationServices/Coordinators/ChildCoordinators/ExploreCoordinator.swift
+++ b/LocationServices/LocationServices/Coordinators/ChildCoordinators/ExploreCoordinator.swift
@@ -87,6 +87,8 @@ extension ExploreCoordinator: ExploreNavigationDelegate {
         controller.presentBottomSheet(parentController: ExploreCoordinator.exploreController!)
         let minHeight = 0.69
         controller.enableBottomSheetGrab(smallHeight: minHeight, mediumHeight: minHeight)
+        
+        NotificationCenter.default.post(name: Notification.updateMapLayerItems, object: nil, userInfo: ["height": controller.getMediumDetentHeight()])
         currentBottomSheet = controller
     }
     

--- a/LocationServices/LocationServices/Scenes/Explore/Controller/ExploreVC.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Controller/ExploreVC.swift
@@ -238,7 +238,7 @@ extension ExploreVC {
         NotificationCenter.default.addObserver(self, selector: #selector(updateMapViewValue(_:)), name: Notification.Name("UpdateMapViewValues"), object: nil)
         
         
-        NotificationCenter.default.addObserver(self, selector: #selector(dismissNavigationScene(_:)), name: Notification.Name("DirectionViewDismissed"), object: nil)
+        NotificationCenter.default.addObserver(self, selector: #selector(dismissDirectionScene(_:)), name: Notification.Name("DirectionViewDismissed"), object: nil)
         
         
         NotificationCenter.default.addObserver(self, selector: #selector(refreshMapView(_:)), name: Notification.refreshMapView, object: nil)
@@ -426,6 +426,12 @@ extension ExploreVC {
         mapNavigationView.isHidden = true
         mapNavigationActionsView.isHidden = true
         //updateAmazonLogoPositioning(isBottomNavigationShown: false)
+        exploreView.hideGeoFence(state: false)
+        exploreView.deleteDrawing()
+    }
+    
+    @objc private func dismissDirectionScene(_ notification: Notification?) {
+        viewModel.deactivateRoute()
         exploreView.hideDirectionButton(state: false)
         exploreView.hideGeoFence(state: false)
         exploreView.hideMapStyleButton(state: false)

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Direction/Controller/DirectionVC+Tableview.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Direction/Controller/DirectionVC+Tableview.swift
@@ -127,6 +127,6 @@ extension DirectionVC: UITableViewDataSource {
                                     "DestinationLocation": destinationLocation,
                                     "routeType": routeType]
         NotificationCenter.default.post(name: Notification.Name("DirectionLineString"), object: nil, userInfo: datas)
-        NotificationCenter.default.post(name: Notification.Name("updateMapViewButtons"), object: nil, userInfo: nil)
+        //NotificationCenter.default.post(name: Notification.Name("updateMapViewButtons"), object: nil, userInfo: nil)
     }
 }

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/View/NavigationVCView.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/View/NavigationVCView.swift
@@ -189,7 +189,7 @@ final class NavigationHeaderView: UIView {
         }
         
         routeVisibilityButton.snp.makeConstraints {
-            $0.width.equalTo(110).priority(999)
+            $0.width.equalTo(90).priority(999)
         }
         
         exitButton.snp.makeConstraints {


### PR DESCRIPTION
[Fixed ALS-1560 directions button](https://github.com/aws-geospatial/amazon-location-features-demo-ios/pull/45/commits/38c7718bfe8fdc06a3ae83a15794bb5682808854)
[Fixed ALS-1563 [iPad] - Routing - Time of travel overlaps with view route button](https://makeen.atlassian.net/browse/ALS-1563)