### PR TITLE
Fixed Settings navigation issues

### DIFF
--- a/LocationServices/LocationServices/Coordinators/ChildCoordinators/SettingsCoordinator.swift
+++ b/LocationServices/LocationServices/Coordinators/ChildCoordinators/SettingsCoordinator.swift
@@ -32,6 +32,7 @@ private extension SettingsCoordinator {
 
 extension SettingsCoordinator: SettingsNavigationDelegate {
     func showNextScene(type: SettingsCellType) {
+        navigationController.navigationBar.isHidden = false
         switch type {
         case .units:
             showUnitScene()

--- a/LocationServices/LocationServices/Scenes/Settings/Controller/SettingsVC.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Controller/SettingsVC.swift
@@ -15,7 +15,7 @@ final class SettingsVC: UIViewController {
         static let horizontalOffset: CGFloat = 16
     }
     
-    weak var delegate: SettingsNavigationDelegate?
+    var delegate: SettingsNavigationDelegate?
     
     private var headerTitle: LargeTitleLabel = {
         let label = LargeTitleLabel(labelText: StringConstant.settigns)

--- a/LocationServices/LocationServices/Scenes/Settings/Subviews/MapStyle/Builder/MapStyleBuilder.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Subviews/MapStyle/Builder/MapStyleBuilder.swift
@@ -10,6 +10,7 @@ import UIKit
 final class MapStyleBuilder {
     static func create() -> MapStyleVC {
         let controller = MapStyleVC()
+        controller.hidesBottomBarWhenPushed = true
         let viewModel = MapStyleViewModel()
         controller.viewModel = viewModel
         return controller


### PR DESCRIPTION
ALS-1492: [iOS] - Settings - Tab bar is visible inside the map styles option
ALS-1493: [iOS] - Go back arrow disappears after tapping on the connect your AWS account
ALS-1496: [iOS] - Settings and about page items are not openings after tapping on the route button present inside the tracker page 