### PR TITLE
[iOS] Imperial and metric unit support for iOS, search UI change

### DIFF
--- a/LocationServices/LocationServices.xcodeproj/project.pbxproj
+++ b/LocationServices/LocationServices.xcodeproj/project.pbxproj
@@ -373,6 +373,9 @@
 		F16681A029D323B200FBD27C /* UITestGeofenceScreen.swift in Sources */ = {isa = PBXBuildFile; fileRef = F166819F29D323B200FBD27C /* UITestGeofenceScreen.swift */; };
 		F17BE2AE29F7F564001A4ADF /* RoutingAPIServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BE2AD29F7F564001A4ADF /* RoutingAPIServiceMock.swift */; };
 		F17BE2B029F819C2001A4ADF /* SearchViewModelTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = F17BE2AF29F819C2001A4ADF /* SearchViewModelTests.swift */; };
+		F18055DD2D64D2CF00045301 /* UnitModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18055DC2D64D2C700045301 /* UnitModel.swift */; };
+		F18055DF2D64D32200045301 /* UnitTypes.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18055DE2D64D31B00045301 /* UnitTypes.swift */; };
+		F18055E12D65DDE200045301 /* UnitHelper.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18055E02D65DDD800045301 /* UnitHelper.swift */; };
 		F18BD50A2AC481DA008FD008 /* AWSLoginServiceMock.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18BD5092AC481DA008FD008 /* AWSLoginServiceMock.swift */; };
 		F18DEEE42C75942E00335F3E /* CognitoCredentials.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18DEEE32C75942E00335F3E /* CognitoCredentials.swift */; };
 		F18DEEE62C75947000335F3E /* Logger.swift in Sources */ = {isa = PBXBuildFile; fileRef = F18DEEE52C75947000335F3E /* Logger.swift */; };
@@ -805,6 +808,9 @@
 		F166819F29D323B200FBD27C /* UITestGeofenceScreen.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UITestGeofenceScreen.swift; sourceTree = "<group>"; };
 		F17BE2AD29F7F564001A4ADF /* RoutingAPIServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RoutingAPIServiceMock.swift; sourceTree = "<group>"; };
 		F17BE2AF29F819C2001A4ADF /* SearchViewModelTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SearchViewModelTests.swift; sourceTree = "<group>"; };
+		F18055DC2D64D2C700045301 /* UnitModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitModel.swift; sourceTree = "<group>"; };
+		F18055DE2D64D31B00045301 /* UnitTypes.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitTypes.swift; sourceTree = "<group>"; };
+		F18055E02D65DDD800045301 /* UnitHelper.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = UnitHelper.swift; sourceTree = "<group>"; };
 		F18BD5092AC481DA008FD008 /* AWSLoginServiceMock.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AWSLoginServiceMock.swift; sourceTree = "<group>"; };
 		F18DEEE32C75942E00335F3E /* CognitoCredentials.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CognitoCredentials.swift; sourceTree = "<group>"; };
 		F18DEEE52C75947000335F3E /* Logger.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = Logger.swift; sourceTree = "<group>"; };
@@ -1300,6 +1306,7 @@
 				F1F0C5862A0E5401009C7151 /* ErrorHandler.swift */,
 				F1F0C5882A13C19E009C7151 /* GeneralHelper.swift */,
 				F18DEEE32C75942E00335F3E /* CognitoCredentials.swift */,
+				F18055E02D65DDD800045301 /* UnitHelper.swift */,
 				F18DEEE52C75947000335F3E /* Logger.swift */,
 			);
 			path = Helpers;
@@ -2415,6 +2422,7 @@
 		ADD139502980831C0003F917 /* Units */ = {
 			isa = PBXGroup;
 			children = (
+				F18055DB2D64D2B100045301 /* Models */,
 				ADD139542980866E0003F917 /* Conracts */,
 				ADD13953298086620003F917 /* Viewmodel */,
 				ADD139522980865B0003F917 /* Builder */,
@@ -2972,6 +2980,15 @@
 			path = Controller;
 			sourceTree = "<group>";
 		};
+		F18055DB2D64D2B100045301 /* Models */ = {
+			isa = PBXGroup;
+			children = (
+				F18055DE2D64D31B00045301 /* UnitTypes.swift */,
+				F18055DC2D64D2C700045301 /* UnitModel.swift */,
+			);
+			path = Models;
+			sourceTree = "<group>";
+		};
 		F18DEEF72C77504900335F3E /* iot */ = {
 			isa = PBXGroup;
 			children = (
@@ -3446,6 +3463,7 @@
 				AD20616D2968A83A005F8BBB /* LoginVC.swift in Sources */,
 				ADBDDEFA29842CC500696EC6 /* ExploreMapStyleViewModel.swift in Sources */,
 				ADD1397E29809BF00003F917 /* ResetPasswordBuilder.swift in Sources */,
+				F18055DD2D64D2CF00045301 /* UnitModel.swift in Sources */,
 				ADBDDEEF29830E8B00696EC6 /* CommonSelectableCell.swift in Sources */,
 				ADD13970298097890003F917 /* DataProviderViewModel.swift in Sources */,
 				ADD5D7BB296F7EFC0022480B /* GeofenceDashboardVC.swift in Sources */,
@@ -3471,6 +3489,7 @@
 				ADC1249C2978A56E00B08C20 /* GeofenceDashboardContracts.swift in Sources */,
 				8AD132752A267FCC00608FCD /* KeyboardObserver.swift in Sources */,
 				F1F0C5892A13C19E009C7151 /* GeneralHelper.swift in Sources */,
+				F18055E12D65DDE200045301 /* UnitHelper.swift in Sources */,
 				ADD5D7E2296F87FF0022480B /* AddGeofenceContracts.swift in Sources */,
 				AD2AF09F292EA91200149904 /* GeofenceCoordinator.swift in Sources */,
 				AD2AF064292E929C00149904 /* Coordinator.swift in Sources */,
@@ -3504,6 +3523,7 @@
 				8A0EB58A2983F9CF00FBB3E5 /* GeofenceAnnotation.swift in Sources */,
 				8A439F0829C0BA1B00B59D0B /* UIApplication+Extension.swift in Sources */,
 				ADF26F59292FECA9000147A0 /* SearchTextField.swift in Sources */,
+				F18055DF2D64D32200045301 /* UnitTypes.swift in Sources */,
 				AD20616F2968A841005F8BBB /* LoginVCBuilder.swift in Sources */,
 				F18DEEE42C75942E00335F3E /* CognitoCredentials.swift in Sources */,
 				ADBD7FBD2949C699005DB4E4 /* POICardVCBuilder.swift in Sources */,

--- a/LocationServices/LocationServices/Constants/AppConstants.swift
+++ b/LocationServices/LocationServices/Constants/AppConstants.swift
@@ -12,7 +12,7 @@ final class DefaultUserSettings {
                                         imageType: .standard,
                                         isSelected: true)
     static let mapStyleColorType = MapStyleColorType.light
-    static let unitValue = "Metric"
+    static let unitValue = UnitTypes.automatic
 }
 
 final class DefaultMapStyles {

--- a/LocationServices/LocationServices/Extensions/Double+Extension.swift
+++ b/LocationServices/LocationServices/Extensions/Double+Extension.swift
@@ -28,20 +28,21 @@ extension Double {
         }
     }
     
-    func convertFormattedKMString() -> String {
-        let distanceInMeters = convertKMToMeters()
-        return distanceInMeters.formatToKmString()
-    }
-    
-    func convertKMToMeters() -> Double {
-        return self * 1000
+    func formatDistance(decimalPoints: Int = 2) -> String {
+        let unitType = UnitHelper.getResolvedUnit()
+        let num = Double(self)
+        let factor = pow(10.0, Double(decimalPoints))
+        
+        if unitType == .metric {
+            let result = (num / 1000 * factor).rounded() / factor // Convert meters to km and round
+            return String(format: "%.\(decimalPoints)f km", result)
+        } else {
+            let numMiles = (convertMetersToMiles(meters: num) * factor).rounded() / factor
+            return String(format: "%.\(decimalPoints)f mi", numMiles)
+        }
     }
 
-    func formatToKmString() -> String {
-        if self >= 1000 {
-            return String(format: "%.2f km", self / 1000)
-        } else {
-            return String(format: "%.0f m", self)
-        }
+    private func convertMetersToMiles(meters: Double) -> Double {
+        return meters * 0.00062137
     }
 }

--- a/LocationServices/LocationServices/Extensions/Int+Extension.swift
+++ b/LocationServices/LocationServices/Extensions/Int+Extension.swift
@@ -18,18 +18,11 @@ extension Int {
         return formatter
     }()
     
-    func formatToKmString() -> String {
-        let num: Double = Double(self)
-        if num > 1000 {
-            let result = Double(round(num * 1000 / 1000) / 1000)
-            return String(format: "%.2f", result) + " km"
-        } else {
-            return "\(num) m"
-        }
+    func formatDistance(decimalPoints: Int = 2) -> String {
+        let num = Double(self)
+        return num.formatDistance(decimalPoints: decimalPoints)
     }
-    
 
-    
     func convertSecondsToMinString() -> String {
         if let formattedString = Self.durationFormatter.string(from: Double(self)) {
             return formattedString
@@ -41,13 +34,8 @@ extension Int {
 }
 
 extension Int64 {
-    func formatToKmString() -> String {
-        let num: Double = Double(self)
-        if num > 1000 {
-            let result = Double(round(num * 1000 / 1000) / 1000)
-            return String(format: "%.2f", result) + " km"
-        } else {
-            return "\(num) m"
-        }
+    func formatDistance(decimalPoints: Int = 2) -> String {
+        let num = Double(self)
+        return num.formatDistance(decimalPoints: decimalPoints)
     }
 }

--- a/LocationServices/LocationServices/Helpers/SettingsDefaultValueHelper.swift
+++ b/LocationServices/LocationServices/Helpers/SettingsDefaultValueHelper.swift
@@ -20,7 +20,7 @@ final class SettingsDefaultValueHelper {
             UserDefaultsHelper.saveObject(value: DefaultUserSettings.mapStyleColorType, key: .mapStyleColorType)
         }
         
-        if UserDefaultsHelper.get(for: String.self, key: .unitType) == nil {
+        if UserDefaultsHelper.getObject(value: UnitTypes.self, key: .unitType) == nil {
             UserDefaultsHelper.saveObject(value: DefaultUserSettings.unitValue, key: .unitType)
         }
         

--- a/LocationServices/LocationServices/Helpers/UnitHelper.swift
+++ b/LocationServices/LocationServices/Helpers/UnitHelper.swift
@@ -1,0 +1,26 @@
+//
+//  UnitHelper.swift
+//  LocationServices
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Foundation
+
+class UnitHelper {
+    public static func getLocaleUnit() -> UnitTypes {
+        let locale = Locale.current
+        let nonMetricCountries: Set<String> = ["US", "MM", "LR"]
+        return nonMetricCountries.contains(locale.region?.identifier.uppercased() ?? "") ? UnitTypes.imperial : UnitTypes.metric
+    }
+    
+    public static func getResolvedUnit() -> UnitTypes? {
+        let unitType = UserDefaultsHelper.getObject(value: UnitTypes.self, key: .unitType)
+        if unitType == .automatic {
+            return getLocaleUnit()
+        }
+        else {
+            return unitType
+        }
+    }
+}

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Direction/ViewModel/DirectionViewModel.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Direction/ViewModel/DirectionViewModel.swift
@@ -286,19 +286,19 @@ final class DirectionViewModel: DirectionViewModelProtocol {
                     routeTime = Date.convertStringToDate(routeTime, format: "yyyy-MM-dd'T'HH:mm:ssXXX")?.convertTimeString() ?? ""
                     switch model.travelMode {
                     case .car:
-                        directionVM.carTypeDistane = model.route.summary?.distance.formatToKmString() ?? ""
+                        directionVM.carTypeDistane = model.route.summary?.distance.formatDistance() ?? ""
                         directionVM.carTypeDuration = model.route.summary?.duration.convertSecondsToMinString() ?? ""
                         directionVM.carTypeTime = routeTime
                     case .scooter:
-                        directionVM.scooterTypeDistance = model.route.summary?.distance.formatToKmString() ?? ""
+                        directionVM.scooterTypeDistance = model.route.summary?.distance.formatDistance() ?? ""
                         directionVM.scooterTypeDuration = model.route.summary?.duration.convertSecondsToMinString() ?? ""
                         directionVM.scooterTypeTime = routeTime
                     case .pedestrian:
-                        directionVM.walkingTypeDistance = model.route.summary?.distance.formatToKmString() ?? ""
+                        directionVM.walkingTypeDistance = model.route.summary?.distance.formatDistance() ?? ""
                         directionVM.walkingTypeDuration = model.route.summary?.duration.convertSecondsToMinString() ?? ""
                         directionVM.walkingTypeTime = routeTime
                     case .truck:
-                        directionVM.truckTypeDistance = model.route.summary?.distance.formatToKmString() ?? ""
+                        directionVM.truckTypeDistance = model.route.summary?.distance.formatDistance() ?? ""
                         directionVM.truckTypeDuration = model.route.summary?.duration.convertSecondsToMinString() ?? ""
                         directionVM.truckTypeTime = routeTime
                     default: break

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/Controller/NavigationVC+TableView.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/Controller/NavigationVC+TableView.swift
@@ -16,8 +16,9 @@ extension NavigationVC {
 }
 
 extension NavigationVC: UITableViewDelegate {
+   
     func tableView(_ tableView: UITableView, heightForRowAt indexPath: IndexPath) -> CGFloat {
-        return 52
+        return Constants.navigationCellRowHeight
     }
 }
 

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/Controller/NavigationVC.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/Controller/NavigationVC.swift
@@ -13,6 +13,7 @@ final class NavigationVC: UIViewController {
     enum Constants {
         static let navigationHeaderHeight: CGFloat = 80
         static let titleLeadingOffset: CGFloat = 16
+        static let navigationCellRowHeight: CGFloat = 52
     }
     
     weak var delegate: ExploreNavigationDelegate?
@@ -238,15 +239,17 @@ final class NavigationVC: UIViewController {
 
         destinationStackView.snp.makeConstraints {
             $0.leading.equalToSuperview().offset(Constants.titleLeadingOffset)
-            $0.top.equalTo(tableView.snp.bottom).offset(16)
+            $0.top.equalTo(tableView.snp.bottom).offset(32)
             $0.height.equalTo(44)
         }
     }
 
     private func adjustTableViewHeight() {
         tableView.layoutIfNeeded()
+        let legsCount = viewModel.getData().count
+        let height = CGFloat(legsCount) * Constants.navigationCellRowHeight
         tableView.snp.updateConstraints {
-            $0.height.equalTo(tableView.contentSize.height+50)
+            $0.height.equalTo(height)
         }
     }
     

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/View/Cell/NavigationVCCell.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/View/Cell/NavigationVCCell.swift
@@ -28,11 +28,11 @@ struct NavigationCellModel {
         self.distance = ""
         self.instruction = ""
         if let step = model.pedestrianStep {
-            self.distance =  String(step.distance)
+            self.distance =  String(step.distance.formatDistance(decimalPoints: 2))
             self.instruction = step.instruction!
         }
         else if let step = model.vehicleStep {
-            self.distance =  String(step.distance)
+            self.distance =  String(step.distance.formatDistance(decimalPoints: 2))
             self.instruction = step.instruction!
         }
         self.stepState = stepState ?? .first
@@ -64,7 +64,7 @@ final class NavigationVCCell: UITableViewCell {
     var model: NavigationCellModel! {
         didSet {
             self.streetLabel.text = model.instruction
-            self.distanceLabel.text = model.distance+" m"
+            self.distanceLabel.text = model.distance
 
             switch model.stepState {
             case .first, .last:

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/ViewModel/NavigationViewModel.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Navigation/ViewModel/NavigationViewModel.swift
@@ -89,7 +89,7 @@ final class NavigationVCViewModel {
         else if let leg = lastLeg?.vehicleLegDetails, let arrival = leg.arrival, let time = arrival.time {
             arrivalTime = time
         }
-        return (route.summary!.distance.formatToKmString(),
+        return (route.summary!.distance.formatDistance(),
                 route.summary!.duration.convertSecondsToMinString(),
                 arrivalTime)
     }

--- a/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Search/Views/Cell/SearchCell.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Sub-Scenes/Search/Views/Cell/SearchCell.swift
@@ -26,6 +26,11 @@ final class SearchCell: UITableViewCell {
     
     private let containerView: UIView = UIView()
     private let contentCellView: UIView = UIView()
+    private let subView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .clear
+        return view
+    }()
     
     var model: SearchCellViewModel! {
         didSet {
@@ -49,20 +54,18 @@ final class SearchCell: UITableViewCell {
             }
             
             if model.searchType == .location {
-                self.locationDistance.isHidden = false
-                self.locationAddress.isHidden = false
-                self.locationDistance.text = model.locationDistance?.formatToKmString()
-                locationAddress.snp.remakeConstraints {
+                self.subView.isHidden = false
+                self.locationDistance.text = model.locationDistance?.formatDistance()
+                subView.snp.remakeConstraints {
                     $0.top.equalTo(locationTitle.snp.bottom).offset(5)
-                    $0.leading.equalTo(locationTitle.snp.leading)
-                    $0.trailing.equalToSuperview().offset(-30)
+                    $0.leading.trailing.equalToSuperview()
                     $0.bottom.equalTo(contentCellView.snp.bottom)
+                    $0.height.equalTo(18)
                 }
             } else {
-                self.locationDistance.isHidden = true
+                self.subView.isHidden = true
                 updateConstraintsForTitle(shouldAlingCenter: true)
-                self.locationAddress.isHidden = true
-                locationAddress.snp.remakeConstraints{
+                subView.snp.remakeConstraints{
                     $0.width.equalTo(0)
                     $0.height.equalTo(0)
                 }
@@ -101,11 +104,18 @@ final class SearchCell: UITableViewCell {
     private let locationDistance: UILabel = {
         let label = UILabel()
         label.font = .amazonFont(type: .regular, size: 13)
-        label.textAlignment = .right
-        label.textColor = .tertiaryColor
+        label.textAlignment = .left
+        label.textColor = .gray
         label.setContentHuggingPriority(UILayoutPriority(251), for: .horizontal)
         label.setContentCompressionResistancePriority(UILayoutPriority(751), for: .horizontal)
         return label
+    }()
+    
+    private let dotView: UIView = {
+        let view = UIView()
+        view.backgroundColor = .lsGrey
+        view.layer.cornerRadius = 5
+        return view
     }()
     
     override init(style: UITableViewCell.CellStyle, reuseIdentifier: String?) {
@@ -123,8 +133,9 @@ final class SearchCell: UITableViewCell {
             }
         } else {
             locationTitle.snp.remakeConstraints {
+                $0.leading.equalToSuperview()
                 $0.top.equalToSuperview()
-                $0.trailing.lessThanOrEqualTo(locationDistance.snp.leading).offset(-8)
+                $0.trailing.lessThanOrEqualToSuperview().offset(-12)
             }
         }
     }
@@ -158,8 +169,10 @@ private extension SearchCell {
         containerView.addSubview(contentCellView)
         containerView.addSubview(searchTypeImage)
         contentCellView.addSubview(locationTitle)
-        contentCellView.addSubview(locationAddress)
-        contentCellView.addSubview(locationDistance)
+        contentCellView.addSubview(subView)
+        subView.addSubview(locationDistance)
+        subView.addSubview(dotView)
+        subView.addSubview(locationAddress)
         
         containerView.snp.makeConstraints {
             $0.top.leading.trailing.bottom.equalToSuperview()
@@ -178,21 +191,32 @@ private extension SearchCell {
             $0.centerY.equalToSuperview()
         }
         
-        locationDistance.snp.makeConstraints {
-            $0.centerY.equalTo(locationTitle.snp.centerY)
-            $0.trailing.equalToSuperview()
-        }
-        
         locationTitle.snp.makeConstraints {
             $0.top.leading.equalToSuperview()
-            $0.trailing.lessThanOrEqualTo(locationDistance.snp.leading).offset(-12)
+            $0.trailing.equalToSuperview().offset(-16)
+        }
+        
+        subView.snp.makeConstraints {
+            $0.top.equalTo(locationTitle.snp.bottom).offset(5)
+            $0.leading.trailing.equalToSuperview()
+            $0.bottom.equalTo(contentCellView.snp.bottom)
+            $0.height.equalTo(18)
+        }
+        
+        locationDistance.snp.makeConstraints {
+            $0.top.bottom.leading.equalToSuperview()
         }
 
+        dotView.snp.makeConstraints {
+            $0.leading.equalTo(locationDistance.snp.trailing).offset(5)
+            $0.height.width.equalTo(5)
+            $0.centerY.equalTo(locationDistance.snp.centerY)
+        }
+        
         locationAddress.snp.makeConstraints {
-            $0.top.equalTo(locationTitle.snp.bottom).offset(5)
-            $0.leading.equalTo(locationTitle.snp.leading)
-            $0.trailing.equalToSuperview().offset(-20)
-            $0.bottom.equalTo(contentCellView.snp.bottom)
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalTo(dotView.snp.trailing).offset(5)
+            $0.trailing.equalToSuperview().offset(-16)
         }
     }
 }
@@ -200,5 +224,11 @@ private extension SearchCell {
 extension SearchCell {
     func hideDistance() {
         locationDistance.isHidden = true
+        dotView.isHidden = true
+        locationAddress.snp.remakeConstraints {
+            $0.top.bottom.equalToSuperview()
+            $0.leading.equalToSuperview()
+            $0.trailing.equalToSuperview().offset(-16)
+        }
     }
 }

--- a/LocationServices/LocationServices/Scenes/Explore/Views/MapNavigationView.swift
+++ b/LocationServices/LocationServices/Scenes/Explore/Views/MapNavigationView.swift
@@ -12,8 +12,6 @@ final class MapNavigationView: UIView {
     private var containerView: UIView = {
         let view = UIView()
         view.backgroundColor = .white
-        //view.layer.cornerRadius = 8
-        //view.setShadow(shadowOpacity: 0.3, shadowBlur: 5)
     return view
     }()
     
@@ -57,7 +55,7 @@ final class MapNavigationView: UIView {
     
     func updateValues(distance: String?, street: String?, stepImage: UIImage?) {
         if let distance = distance {
-            distanceLabel.text = "\(distance) m"
+            distanceLabel.text = distance
         }
         streetLabel.text = street
         self.stepImage.image = stepImage

--- a/LocationServices/LocationServices/Scenes/Geofence/SubViews/AddGeofence/Views/AddGeofenceSearchView.swift
+++ b/LocationServices/LocationServices/Scenes/Geofence/SubViews/AddGeofence/Views/AddGeofenceSearchView.swift
@@ -85,7 +85,7 @@ final class AddGeofenceSearchView: UIView {
     @objc private func geofenceRadiusDragged(_ notification: Notification){
         let radius = notification.userInfo?["radius"] as! Double
         radiusSlider.value = Float(radius)
-        radiusSliderValue.text = Int(radius).formatToKmString()
+        radiusSliderValue.text = Int(radius).formatDistance()
         radiusValueHander?(radius)
     }
     
@@ -119,7 +119,7 @@ final class AddGeofenceSearchView: UIView {
             
             if let radius = model.radius {
                 self?.radiusSlider.value = Float(radius)
-                self?.radiusSliderValue.text = radius.formatToKmString()
+                self?.radiusSliderValue.text = radius.formatDistance()
             }
         }
     }
@@ -183,7 +183,7 @@ final class AddGeofenceSearchView: UIView {
 extension AddGeofenceSearchView {
     @objc func radiusSliderValuChanged(sender: UISlider) {
         let value = Double(radiusSlider.value)
-        self.radiusSliderValue.text = value.formatToKmString()
+        self.radiusSliderValue.text = value.formatDistance()
         radiusValueHander?(value)
     }
     

--- a/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Models/UnitModel.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Models/UnitModel.swift
@@ -1,0 +1,13 @@
+//
+//  UnitModel.swift
+//  LocationServices
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import UIKit
+
+struct UnitModel: Codable {
+    var title: String
+    var isSelected: Bool
+}

--- a/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Models/UnitTypes.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Models/UnitTypes.swift
@@ -1,0 +1,34 @@
+//
+//  UnitTypes.swift
+//  LocationServices
+//
+// Copyright Amazon.com, Inc. or its affiliates. All Rights Reserved.
+// SPDX-License-Identifier: MIT-0
+
+import Foundation
+
+enum UnitTypes: Codable  {
+    case automatic, imperial, metric
+    
+    var title: String {
+        switch self {
+        case .automatic:
+            return "Automatic"
+        case .imperial:
+            return "Imperial"
+        case .metric:
+            return "Metric"
+        }
+    }
+    
+    var subTitle: String {
+        switch self {
+        case .automatic:
+            return "Based on your browser settings (\(UnitHelper.getLocaleUnit().subTitle))"
+        case .imperial:
+            return "Miles, pounds"
+        case .metric:
+            return "Kilometers, kilograms"
+        }
+    }
+}

--- a/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Viewmodel/UnitSceneViewModel.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Subviews/Units/Viewmodel/UnitSceneViewModel.swift
@@ -11,21 +11,24 @@ final class UnitSceneViewModel: UnitSceneViewModelProcotol {
     var delegate: UnitSceneViewModelOutputDelegate?
     
     private var initialDatas: [CommonSelectableCellModel] = [
-        CommonSelectableCellModel(title: "Automatic",
-                                  subTitle: nil,
+        CommonSelectableCellModel(title: UnitTypes.automatic.title,
+                                  subTitle: UnitTypes.automatic.subTitle,
                                   isSelected: true,
-                                  identifier: "Automatic"),
-        CommonSelectableCellModel(title: "Imperial",
-                                  subTitle: "Miles, pounds",
+                                  identifier: UnitTypes.automatic.title,
+                                  unitType: UnitTypes.automatic),
+        CommonSelectableCellModel(title: UnitTypes.imperial.title,
+                                  subTitle: UnitTypes.imperial.subTitle,
                                   isSelected: false,
-                                  identifier: "Imperial"),
-        CommonSelectableCellModel(title: "Metric",
-                                  subTitle: "Kilometers, kilograms",
+                                  identifier: UnitTypes.imperial.title,
+                                  unitType: UnitTypes.imperial),
+        CommonSelectableCellModel(title: UnitTypes.metric.title,
+                                  subTitle: UnitTypes.metric.subTitle,
                                   isSelected: false,
-                                  identifier: "Metric")
+                                  identifier: UnitTypes.metric.title,
+                                  unitType: UnitTypes.metric)
     ]
     func loadCurrentData() {
-        let index =  getDataFromLocal()
+        let index = getDataFromLocal()
         delegate?.updateTableView(index: index)
     }
     
@@ -38,8 +41,9 @@ final class UnitSceneViewModel: UnitSceneViewModelProcotol {
     }
     
     func saveSelectedState(_ indexPath: IndexPath) {
-        let title = initialDatas[indexPath.row].title
-        saveUnitSettingsData(title: title)
+        if let unitType = initialDatas[indexPath.row].unitType {
+            saveUnitSettingsData(unitType: unitType)
+        }
         delegate?.updateTableView(index: indexPath.row)
     }
 }
@@ -47,10 +51,10 @@ final class UnitSceneViewModel: UnitSceneViewModelProcotol {
 private extension UnitSceneViewModel {
     func getDataFromLocal() -> Int {
         var currentDataIndex = 0
-        let localData =  UserDefaultsHelper.get(for: String.self, key: .unitType)
+        let localData =  UserDefaultsHelper.getObject(value: UnitTypes.self, key: .unitType)
         
         for index in initialDatas.indices {
-            if initialDatas[index].title == localData {
+            if initialDatas[index].title == localData?.title {
                 currentDataIndex = index
                 initialDatas[index].isSelected = true
             } else {
@@ -60,7 +64,7 @@ private extension UnitSceneViewModel {
         return currentDataIndex
     }
     
-    func saveUnitSettingsData(title: String) {
-        UserDefaultsHelper.save(value: title, key: .unitType)
+    func saveUnitSettingsData(unitType: UnitTypes) {
+        UserDefaultsHelper.saveObject(value: unitType, key: .unitType)
     }
 }

--- a/LocationServices/LocationServices/Scenes/Settings/ViewModel/SettingsViewModel.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/ViewModel/SettingsViewModel.swift
@@ -58,9 +58,10 @@ final class SettingsViewModel: SettingsViewModelProtocol {
     
     private func populateConfiguredData() {
         let mapStyle = UserDefaultsHelper.getObject(value: MapStyleModel.self, key: .mapStyle)
-        let unitType = UserDefaultsHelper.get(for: String.self, key: .unitType)
-    
+        let unitType = UserDefaultsHelper.getObject(value: UnitTypes.self, key: .unitType)
+
         datas = [
+            SettingsCellModel(type: .units, subTitle: unitType?.title ?? ""),
             SettingsCellModel(type: .mapStyle, subTitle: mapStyle?.title ?? ""),
             SettingsCellModel(type: .routeOption),
             SettingsCellModel(type: .awsCloud)

--- a/LocationServices/LocationServices/Scenes/Settings/Views/Cell/SettingsCell.swift
+++ b/LocationServices/LocationServices/Scenes/Settings/Views/Cell/SettingsCell.swift
@@ -9,7 +9,7 @@ import UIKit
 import SnapKit
 
 enum SettingsCellType {
-    case units,dataProvider, mapStyle, routeOption, resetPassword, awsCloud
+    case units, dataProvider, mapStyle, routeOption, resetPassword, awsCloud
     
     var title: String {
         switch self {

--- a/LocationServices/LocationServices/Services/RoutingService.swift
+++ b/LocationServices/LocationServices/Services/RoutingService.swift
@@ -49,7 +49,8 @@ extension AWSRoutingServiceProtocol {
         if departureTime != nil || arrivalTime != nil {
             departNow = nil
         }
-        let input = CalculateRoutesInput(arrivalTime: arrivalTime?.convertDateToIsoString(), avoid: routeAvoidanceOptions, departNow: departNow, departureTime: departureTime?.convertDateToIsoString(), destination: destination, instructionsMeasurementSystem: .metric, legAdditionalFeatures: legAdditionalFeatures, legGeometryFormat: .flexiblePolyline, maxAlternatives: 0, origin: origin, travelMode: travelMode, travelStepType: .default)
+        let measureUnit = UnitHelper.getResolvedUnit() == .imperial ? GeoRoutesClientTypes.MeasurementSystem.imperial : GeoRoutesClientTypes.MeasurementSystem.metric
+        let input = CalculateRoutesInput(arrivalTime: arrivalTime?.convertDateToIsoString(), avoid: routeAvoidanceOptions, departNow: departNow, departureTime: departureTime?.convertDateToIsoString(), destination: destination, instructionsMeasurementSystem: measureUnit, legAdditionalFeatures: legAdditionalFeatures, legGeometryFormat: .flexiblePolyline, maxAlternatives: 0, origin: origin, travelMode: travelMode, travelStepType: .default)
         
         if let client = AmazonLocationClient.getRoutesClient() {
             let result = try await client.calculateRoutes(input: input)

--- a/LocationServices/LocationServices/Views/Common/AmazonCustomSelectableView.swift
+++ b/LocationServices/LocationServices/Views/Common/AmazonCustomSelectableView.swift
@@ -9,8 +9,7 @@ import UIKit
 import SnapKit
 
 private enum CustomSelectableConstants {
-    static let circleImage = UIImage(systemName: "circle.fill")
-    static let checkMarkImage = UIImage(systemName: "checkmark.circle.fill")
+    static let checkMarkImage = UIImage.checkMark
 }
 
 final class AmazonCustomSelectableView: UIView {
@@ -33,7 +32,7 @@ final class AmazonCustomSelectableView: UIView {
     
     private var selectionButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setImage(CustomSelectableConstants.circleImage, for: .normal)
+        button.setImage(nil, for: .normal)
         button.imageView?.contentMode = .scaleAspectFill
         button.tintColor = .searchBarBackgroundColor
         button.layer.borderColor = UIColor.searchBarTintColor.cgColor
@@ -76,7 +75,7 @@ final class AmazonCustomSelectableView: UIView {
             selectionButton.layer.borderWidth = 0
             selectionButton.layer.borderColor = UIColor.lsPrimary.cgColor
         } else {
-            selectionButton.setImage(CustomSelectableConstants.circleImage, for: .normal)
+            selectionButton.setImage(nil, for: .normal)
             selectionButton.tintColor = .searchBarBackgroundColor
             selectionButton.layer.borderWidth = 1
             selectionButton.layer.borderColor = UIColor.searchBarTintColor.cgColor
@@ -96,7 +95,7 @@ final class AmazonCustomSelectableView: UIView {
             selectionButton.layer.borderWidth = 0
             selectionButton.layer.borderColor = UIColor.lsPrimary.cgColor
         } else {
-            selectionButton.setImage(CustomSelectableConstants.circleImage, for: .normal)
+            selectionButton.setImage(nil, for: .normal)
             selectionButton.tintColor = .searchBarBackgroundColor
             selectionButton.layer.borderWidth = 1
             selectionButton.layer.borderColor = UIColor.searchBarTintColor.cgColor

--- a/LocationServices/LocationServices/Views/Common/CommonSelectableCell.swift
+++ b/LocationServices/LocationServices/Views/Common/CommonSelectableCell.swift
@@ -9,8 +9,7 @@ import UIKit
 import SnapKit
 
 private enum CommonSelectableCellConstants {
-    static let circleImage = UIImage(systemName: "circle.fill")
-    static let checkMarkImage = UIImage(systemName: "checkmark.circle.fill")
+    static let checkMarkImage = UIImage.checkMark
 }
 
 struct CommonSelectableCellModel {
@@ -18,6 +17,7 @@ struct CommonSelectableCellModel {
     let subTitle: String?
     var isSelected: Bool
     var identifier: String
+    var unitType: UnitTypes?
 }
 
 final class CommonSelectableCell: UITableViewCell {
@@ -38,7 +38,7 @@ final class CommonSelectableCell: UITableViewCell {
     private var title: UILabel = {
         var label = UILabel()
         label.font = .amazonFont(type: .regular, size: 16)
-        label.textColor = .mapDarkBlackColor
+        label.textColor = .lsTetriary
         label.textAlignment = .left
         return label
     }()
@@ -46,19 +46,15 @@ final class CommonSelectableCell: UITableViewCell {
     private var subtitle: UILabel = {
         var label = UILabel()
         label.font = .amazonFont(type: .regular, size: 13)
-        label.textColor = .searchBarTintColor
+        label.textColor = .lsGrey
         label.textAlignment = .left
         return label
     }()
     
     private var selectionButton: UIButton = {
         let button = UIButton(type: .system)
-        button.setImage(CommonSelectableCellConstants.circleImage, for: .normal)
+        button.setImage(nil, for: .normal)
         button.imageView?.contentMode = .scaleAspectFill
-        button.tintColor = .searchBarBackgroundColor
-        button.layer.borderColor = UIColor.searchBarTintColor.cgColor
-        button.layer.borderWidth = 1
-        button.layer.cornerRadius = 10
         return button
     }()
     
@@ -85,14 +81,9 @@ final class CommonSelectableCell: UITableViewCell {
             accessibilityTraits = [.selected]
             selectionButton.setImage(CommonSelectableCellConstants.checkMarkImage, for: .normal)
             selectionButton.tintColor = .lsPrimary
-            selectionButton.layer.borderWidth = 1
-            selectionButton.layer.borderColor = UIColor.lsPrimary.cgColor
         } else {
             accessibilityTraits = []
-            selectionButton.setImage(CommonSelectableCellConstants.circleImage, for: .normal)
-            selectionButton.tintColor = .searchBarBackgroundColor
-            selectionButton.layer.borderWidth = 1
-            selectionButton.layer.borderColor = UIColor.searchBarTintColor.cgColor
+            selectionButton.setImage(nil, for: .normal)
         }
     }
 }
@@ -111,6 +102,14 @@ private extension CommonSelectableCell {
             $0.top.leading.trailing.bottom.equalToSuperview()
         }
         
+        title.snp.makeConstraints {
+            $0.top.equalToSuperview().offset(16)
+        }
+        
+        subtitle.snp.makeConstraints {
+            $0.top.equalTo(title.snp.bottom).offset(8)
+        }
+        
         selectionButton.snp.makeConstraints {
             $0.height.width.equalTo(20)
             $0.trailing.equalToSuperview().offset(-16)
@@ -118,10 +117,10 @@ private extension CommonSelectableCell {
         }
         
         textStackView.snp.makeConstraints {
-            $0.height.equalTo(46)
+            $0.top.bottom.equalToSuperview()
+            $0.height.equalTo(72)
             $0.leading.equalToSuperview().offset(16)
             $0.trailing.equalTo(selectionButton.snp.leading)
-            $0.centerY.equalToSuperview()
         }
     }
 }

--- a/LocationServices/LocationServices/Views/Common/POICardView.swift
+++ b/LocationServices/LocationServices/Views/Common/POICardView.swift
@@ -31,7 +31,7 @@ final class POICardView: UIView {
             if let distance = dataModel.distance, distance != 0 {
                 self.distanceLabel.isHidden = false
                 self.dotView.isHidden = false
-                self.distanceLabel.text = distance.formatToKmString()
+                self.distanceLabel.text = distance.formatDistance()
             } else {
                 self.dotView.isHidden = true
                 self.distanceLabel.isHidden = true

--- a/LocationServices/LocationServicesTests/DoubleExtensionTests.swift
+++ b/LocationServices/LocationServicesTests/DoubleExtensionTests.swift
@@ -23,14 +23,9 @@ final class DoubleExtensionTests: XCTestCase {
        XCTAssertEqual(seconds.convertSecondsToMinString(), "1 hr", "Expected formatted 1 hr string")
     }
     
-    func testConvertKMToM() throws {
-        let km: Double = 1
-       XCTAssertEqual(km.convertKMToMeters(), 1000, "Expected 1000 M")
-    }
-    
-    func testConvertFormattedKMString() throws {
-        let km: Double = 1
-       XCTAssertEqual(km.convertFormattedKMString(), "1.00 km", "Expected formatted KM 1 km string")
+    func testformatDistance() throws {
+        let km: Double = 1000
+       XCTAssertEqual(km.formatDistance(), "0.62 mi", "Expected formatted KM 1 km string")
     }
 
 }

--- a/LocationServices/LocationServicesTests/IntExtensionTests.swift
+++ b/LocationServices/LocationServicesTests/IntExtensionTests.swift
@@ -20,21 +20,21 @@ final class IntExtensionTests: XCTestCase {
 
     func testConvertIntToM() throws {
         let km: Int = 1000
-       XCTAssertEqual(km.formatToKmString(), "1000.0 m", "Expected string km")
+        XCTAssertEqual(km.formatDistance(), "0.62 mi", "Expected string km")
     }
 
     func testConvertInt64ToM() throws {
         let km: Int64 = 1000
-       XCTAssertEqual(km.formatToKmString(), "1000.0 m", "Expected string km")
+       XCTAssertEqual(km.formatDistance(), "0.62 mi", "Expected string km")
     }
     
     func testConvertIntToKM() throws {
         let km: Int = 1001
-       XCTAssertEqual(km.formatToKmString(), "1.00 km", "Expected string km")
+       XCTAssertEqual(km.formatDistance(), "0.62 mi", "Expected string km")
     }
 
     func testConvertInt64ToKM() throws {
         let km: Int64 = 1001
-       XCTAssertEqual(km.formatToKmString(), "1.00 km", "Expected string km")
+       XCTAssertEqual(km.formatDistance(), "0.62 mi", "Expected string km")
     }
 }

--- a/LocationServices/LocationServicesTests/NavigationVCViewModelTests.swift
+++ b/LocationServices/LocationServicesTests/NavigationVCViewModelTests.swift
@@ -52,20 +52,6 @@ final class NavigationVCViewModelTests: XCTestCase {
         XCTAssertEqual(navigationVCViewModel.firstDestination?.placeName, "Times Square", "Expected Times Square place name")
     }
     
-    func testUpdateWithValidData() throws {
-        var legDetails = GeoRoutesClientTypes.RouteVehicleLegDetails(travelSteps: [])
-        var routeLegDetails = GeoRoutesClientTypes.RouteLeg(vehicleLegDetails: legDetails)
-        var route = GeoRoutesClientTypes.Route(legs: [routeLegDetails])
-        let navigationVCViewModel = NavigationVCViewModel(service: LocationService(), route: route, firstDestination: firstDestination, secondDestination: secondDestination)
-
-        let step = GeoRoutesClientTypes.RouteVehicleTravelStep(distance: 2, duration: 2, instruction: "continue", type: .continue)
-        legDetails = GeoRoutesClientTypes.RouteVehicleLegDetails(travelSteps: [step])
-        routeLegDetails = GeoRoutesClientTypes.RouteLeg(vehicleLegDetails: legDetails)
-        route = GeoRoutesClientTypes.Route(legs: [routeLegDetails])
-        navigationVCViewModel.update(route: route)
-        XCTAssertEqual(navigationVCViewModel.route.legs?[0].vehicleLegDetails?.travelSteps?.first?.duration, 2, "Expected steps duration 2")
-    }
-    
     func testGetSummaryData() throws {
         var legDetails = GeoRoutesClientTypes.RouteVehicleLegDetails(travelSteps: [])
         var routeLegDetails = GeoRoutesClientTypes.RouteLeg(vehicleLegDetails: legDetails)
@@ -78,7 +64,7 @@ final class NavigationVCViewModelTests: XCTestCase {
         route = GeoRoutesClientTypes.Route(legs: [routeLegDetails], summary: GeoRoutesClientTypes.RouteSummary(distance: 10, duration: 1, tolls: nil))
         navigationVCViewModel.update(route: route)
         
-        XCTAssertEqual(navigationVCViewModel.getSummaryData().totalDistance, "10.0 m", "Expected summary total distance 1 m")
+        XCTAssertEqual(navigationVCViewModel.getSummaryData().totalDistance, "0.01 mi", "Expected summary total distance 0.01 mi")
     }
     
     func testGetDataWithZeroSteps() throws {


### PR DESCRIPTION
Implemented Metric (Kilometers) and Imperial (Miles) wherever distance is shown as per user or region settings.
There are three options in settings.

![image](https://github.com/user-attachments/assets/aefbfce2-4574-4d03-864a-e3a13703e780)

Issues: 
- [[iOS] Explore > Search Suggestions > The Distance is not displayed adjacent to the location address ](https://makeen.atlassian.net/browse/ALS-2038)
- [[iOS] Imperial and metric unit support for iOS](https://makeen.atlassian.net/browse/ALS-2025)
