### PR TITLE
fix(github): reduced workflow permission scope

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -6,6 +6,8 @@ on:
   workflow_dispatch:
 jobs:
   startSlackNotification:
+    permissions:
+      contents: read
     name: Slack Starting Notification
     runs-on: ubuntu-latest
     steps:
@@ -29,6 +31,9 @@ jobs:
           SLACK_USERNAME: CI/CD Bot
           MSG_MINIMAL: true
   build-iOS:
+    permissions:
+      contents: read
+      actions: write # for upload artifact
     name: Build iOS
     env:
       MATCH_PASSWORD: ${{ secrets.MATCH_PASSWORD }}
@@ -75,6 +80,8 @@ jobs:
       - run: cat /Users/runner/Library/Logs/gym/LocationServices-LocationServices.log
         if: always()
   slackNotification:
+    permissions:
+      contents: read
     name: Slack Final Notification
     needs: [
       build-iOS

--- a/.github/workflows/lint-ios.yml
+++ b/.github/workflows/lint-ios.yml
@@ -5,6 +5,8 @@ on:
 #    branches: [ develop, main ]
 jobs:
   test-iOS:
+    permissions:
+      contents: read
     name: Lint iOS Code
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -5,6 +5,9 @@ on:
     branches: [main]
 jobs:
   test-iOS:
+    permissions:
+      contents: read
+      actions: write # for upload artifact
     name: Test iOS App
     runs-on: macos-15
     steps:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -5,6 +5,8 @@ on:
     branches: [ develop, main ]
 jobs:
   test-iOS:
+    permissions:
+      contents: read
     name: Run Unit Tests for iOS
     runs-on: macos-15
     steps:


### PR DESCRIPTION
*Issue #, if available:*

Address code scan result

*Description of changes:*

Reduce scope of permission for work flows to content read, with action write for jobs that are doing uploading of artifacts.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
