### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -1,4 +1,6 @@
 name: Run E2E Tests for iOS
+permissions:
+  contents: read
 on:
   workflow_dispatch:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/aws-geospatial/amazon-location-features-demo-ios/security/code-scanning/1](https://github.com/aws-geospatial/amazon-location-features-demo-ios/security/code-scanning/1)

To fix the problem, add a `permissions` block to the workflow. Because none of the steps require write access—checkout runs with read access by default, and artifact upload does not require repository permissions—a minimal permissions block should suffice. The most restrictive, and recommended, grant is `contents: read`, placed at the top level (after `name`, before or after `on`) so it applies to all jobs in the workflow, unless individual jobs later require more.

**What to change:**  
- At the root of `.github/workflows/test-ios-e2e.yml`, add the following block:
  ```yaml
  permissions:
    contents: read
  ```
  directly after the workflow `name:`.

**What is needed:**  
- No extra imports, methods, or definitions; just declarative YAML configuration.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
