### PR TITLE
Updated CI to use the bundler cache to improve build/test times

### DIFF
--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -39,6 +39,7 @@ jobs:
       # Use the bundler cache to speed-up build times
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3.9"
           bundler-cache: true
           working-directory: ./LocationServices
 

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -48,6 +48,17 @@ jobs:
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
 
+      # Cache our XCode project dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+            LocationServices/LocationServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved', '**/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Setup Config Files
         working-directory: ./LocationServices
         run: |

--- a/.github/workflows/build-ios.yml
+++ b/.github/workflows/build-ios.yml
@@ -19,8 +19,8 @@ jobs:
         env:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: amazon-location-services-builds
-          SLACK_COLOR: '#FFFF00'
-          SLACK_ICON_EMOJI: ':hammer:'
+          SLACK_COLOR: "#FFFF00"
+          SLACK_ICON_EMOJI: ":hammer:"
           SLACK_LINK_NAMES: true
           SLACK_TITLE: ${{ format('iOS Build №{0} started...', env.BUILD_NUM) }}
           SLACK_MESSAGE: |
@@ -36,19 +36,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
+      # Use the bundler cache to speed-up build times
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: ./LocationServices
+
       - name: Install SSH key
         uses: webfactory/ssh-agent@v0.5.3
         with:
           ssh-private-key: ${{ secrets.SSH_KEY }}
-
-      - name: Setup Bundler
-        working-directory: ./LocationServices
-        run: |
-          bundle config --local path ./vendor/bundle
-          bundle config --local deployment true
-          rbenv install -s 3.3.5
-          rbenv local 3.3.5
-          bundle install
 
       - name: Setup Config Files
         working-directory: ./LocationServices
@@ -76,9 +73,7 @@ jobs:
         if: always()
   slackNotification:
     name: Slack Final Notification
-    needs: [
-      build-iOS
-    ]
+    needs: [build-iOS]
     if: always()
     runs-on: ubuntu-latest
     env:
@@ -95,7 +90,7 @@ jobs:
           SLACK_WEBHOOK: ${{ secrets.SLACK_WEBHOOK }}
           SLACK_CHANNEL: amazon-location-services-builds
           SLACK_COLOR: ${{ env.SUCCESS == 'true' && 'success' || 'failure' }}
-          SLACK_ICON_EMOJI: ':tophat:'
+          SLACK_ICON_EMOJI: ":tophat:"
           SLACK_LINK_NAMES: true
           SLACK_TITLE: ${{ format('iOS build №{0} {1}', env.BUILD_NUM, env.SUCCESS == 'true' && 'finished successfully :tada:' || 'failed!') }}
           SLACK_MESSAGE: |

--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -15,6 +15,7 @@ jobs:
       # Use the bundler cache to speed-up build times
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3.9"
           bundler-cache: true
           working-directory: ./LocationServices
 

--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -19,6 +19,17 @@ jobs:
           bundler-cache: true
           working-directory: ./LocationServices
 
+      # Cache our XCode project dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+            LocationServices/LocationServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved', '**/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Setup Config
         working-directory: ./LocationServices
         run: |

--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -12,12 +12,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Bundler
-        working-directory: ./LocationServices
-        run: |
-          bundle config --local path ./vendor/bundle
-          bundle config --local deployment true
-          bundle install
+      # Use the bundler cache to speed-up build times
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: ./LocationServices
 
       - name: Setup Config
         working-directory: ./LocationServices

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -2,7 +2,7 @@ name: Run Unit Tests for iOS
 on:
   workflow_dispatch:
   pull_request:
-    branches: [ develop, main ]
+    branches: [develop, main]
 jobs:
   test-iOS:
     name: Run Unit Tests for iOS
@@ -10,12 +10,11 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Setup Bundler
-        working-directory: ./LocationServices
-        run: |
-          bundle config --local path ./vendor/bundle
-          bundle config --local deployment true
-          bundle install
+      # Use the bundler cache to speed-up build times
+      - uses: ruby/setup-ruby@v1
+        with:
+          bundler-cache: true
+          working-directory: ./LocationServices
 
       - name: Setup Config
         env:

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -17,6 +17,17 @@ jobs:
           bundler-cache: true
           working-directory: ./LocationServices
 
+      # Cache our XCode project dependencies
+      - uses: actions/cache@v3
+        with:
+          path: |
+            ~/Library/Caches/org.swift.swiftpm
+            ~/Library/Developer/Xcode/DerivedData
+            LocationServices/LocationServices.xcodeproj/project.xcworkspace/xcshareddata/swiftpm
+          key: ${{ runner.os }}-spm-${{ hashFiles('**/Package.resolved', '**/project.xcworkspace/xcshareddata/swiftpm/Package.resolved') }}
+          restore-keys: |
+            ${{ runner.os }}-spm-
+
       - name: Setup Config
         env:
           config: ${{ secrets.CONFIG }}

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -13,6 +13,7 @@ jobs:
       # Use the bundler cache to speed-up build times
       - uses: ruby/setup-ruby@v1
         with:
+          ruby-version: "3.3.9"
           bundler-cache: true
           working-directory: ./LocationServices
 

--- a/LocationServices/.gitignore
+++ b/LocationServices/.gitignore
@@ -22,3 +22,7 @@ amplifytools.xcconfig
 #amplify-do-not-edit-end
 xcov_output/
 test_output/
+
+# gems
+.bundle/
+vendor/

--- a/LocationServices/Gemfile.lock
+++ b/LocationServices/Gemfile.lock
@@ -231,4 +231,4 @@ DEPENDENCIES
   xcov
 
 BUNDLED WITH
-   2.5.17
+   2.7.2


### PR DESCRIPTION
### Description
This PR has several changes, aimed at speeding up our build/test times. The main change is to replace the manual bundle config/install with using a bundler-cache. This will cache our gems between workflow runs, which should greatly improve our build times.

Also, the bundler running on our GitHub runners is a newer version, so we were getting the following warning:

```
Bundler 2.7.2 is running, but your lockfile was generated with 2.5.17. Installing Bundler 2.5.17 and restarting using that version.
```

This was preventing us from taking full advantage of our gem cache, so I've updated the bundle by running:

```
bundle update --bundler
```

Finally, I made a small change to our `.gitignore` so that the bundled gems don't show up as untracked files when developing locally.