### PR TITLE
Fix CI: prevent config overwrite and nil xcresult_path crash

### DIFF
--- a/.github/workflows/test-ios-e2e.yml
+++ b/.github/workflows/test-ios-e2e.yml
@@ -38,11 +38,13 @@ jobs:
 
       - name: Run tests on iPhone
         working-directory: ./LocationServices
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
         run: bundle exec fastlane run_e2e_tests device:"iPhone 16 Pro Max (18.0)"
 
       - name: Upload test results
         uses: actions/upload-artifact@v4
-        if: always()
+        if: always() && env.xcresult_path != ''
         with:
           name: test-results-iphone
           path: ${{ env.xcresult_path }}

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -48,4 +48,6 @@ jobs:
 
       - name: Run tests
         working-directory: ./LocationServices
+        env:
+          FASTLANE_XCODEBUILD_SETTINGS_TIMEOUT: 120
         run: bundle exec fastlane run_unit_tests device:"iPhone 14"

--- a/.github/workflows/test-ios.yml
+++ b/.github/workflows/test-ios.yml
@@ -43,8 +43,8 @@ jobs:
       - name: Ensure config files exist
         working-directory: ./LocationServices
         run: |
-          touch Config.xcconfig
-          touch ConfigTest.xcconfig
+          [ -f Config.xcconfig ] || touch Config.xcconfig
+          [ -f ConfigTest.xcconfig ] || touch ConfigTest.xcconfig
 
       - name: Run tests
         working-directory: ./LocationServices

--- a/LocationServices/fastlane/Fastfile
+++ b/LocationServices/fastlane/Fastfile
@@ -50,7 +50,7 @@ platform :ios do
       )
     ensure
       xcresult_path = Actions.lane_context[SharedValues::SCAN_GENERATED_XCRESULT_PATH]
-      sh("echo xcresult_path=" + xcresult_path + " >> $GITHUB_ENV")
+      sh("echo xcresult_path=#{xcresult_path || ''} >> $GITHUB_ENV") if ENV['GITHUB_ENV']
     end
   end
 


### PR DESCRIPTION
*Issue #, if available:*

This should address the failing approval workflows which have not successfully passed in the last 2 months. 

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
